### PR TITLE
HybridSessionStore, added parameter to gc call

### DIFF
--- a/code/HybridSessionStore.php
+++ b/code/HybridSessionStore.php
@@ -511,7 +511,7 @@ class HybridSessionStore extends HybridSessionStore_Base {
 
 	public function gc($maxlifetime) {
 		foreach ($this->handlers as $handler) {
-			$handler->gc();
+			$handler->gc($maxlifetime);
 		}
 	}
 


### PR DESCRIPTION
The gc method expects one parameter (maxlifetime), even if there is no use for it. The parameter was available but was not passed on. This lead to a warning in the php log:
PHP Warning:  Missing argument 1 for HybridSessionStore_Database::gc(), called in /hybridsessions/code/HybridSessionStore.php on line 514 and defined in /hybridsessions/code/HybridSessionStore.php on line 428